### PR TITLE
Add Podspec file

### DIFF
--- a/Library/Shared/PSDWriter.m
+++ b/Library/Shared/PSDWriter.m
@@ -305,6 +305,7 @@ char *blendModes[36] =
     [effectInfo appendValue:75 withLength:1];    // Opacity as a percent
     }
 
+    return [[NSMutableData alloc] init];
 }
 
 - (NSData *)createPSDData

--- a/PSDWriter.podspec
+++ b/PSDWriter.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  spec.name         = "PSDWriter"
+  spec.version      = "1.0.0"
+  spec.summary      = "An Objective-C library for creating layered PSDs from a set of images on Mac OS X or iOS"
+  spec.description  = <<-DESC
+An Objective-C library for creating layered PSDs from a set of images on Mac OS X or iOS  
+                   DESC
+
+  spec.homepage     = "https://github.com/bengotow/PSDWriter"
+  spec.license      = { :file => "LICENSE.txt" }
+  spec.author       = "Ben Gotow"
+
+  spec.source       = { :git => "https://github.com/bengotow/PSDWriter.git", :commit => "fc765dacfa0e8dc09d49918627a111362b9ed13b" }
+  spec.source_files  = "Library/Shared/*.{h,m}"
+  spec.exclude_files = "Classes/Exclude"
+  spec.public_header_files = "Library/Shared/PSDWriter.h"
+
+  spec.requires_arc = false
+end


### PR DESCRIPTION
Hi Ben! Thank you for sharing PSDWriter. It still works wonderfully.

This pull request adds a Podspec file so PSDWriter can be used with Cocoapods. I prefer managing my dependencies with Cocoapods, since then I can use something like [AcknowList](https://cocoapods.org/pods/Acknowlist) to gather all copyright notices in one place.

I assigned version 1.0.0 in the Podfile as it PSDWriter has proved stable in my testing, but I have not tagged any commits. I tested the pod spec by pointing it to my branch (`  pod 'PSDWriter', :git => 'git@github.com:hristost/PSDWriter.git', :branch => 'hristost/add-podspec'`) and it worked fine.