### PR TITLE
Fix crash for layer names with non-ascii characters

### DIFF
--- a/Library/Shared/PSDWriter.m
+++ b/Library/Shared/PSDWriter.m
@@ -627,7 +627,7 @@ char *blendModes[36] =
 
 		NSString *layerName = [[aLayer name] stringByAppendingString:@" "];
 		layerName = [layerName stringByPaddingToLength:15 withString:@" " startingAtIndex:0];
-		const char *layerNameCString = [layerName cStringUsingEncoding:NSStringEncodingConversionAllowLossy];
+		const char *layerNameCString = [layerName cStringUsingEncoding:NSUTF8StringEncoding];
 		// Layer name: Pascal string 1 byte length + text, padded to a multiple of 4 bytes.
 		NSInteger len =  [layerName length] ;
 		[layerInfo appendValue:len withLength:1];


### PR DESCRIPTION
This pull requests fixes a crash that would occur if a layer name used non-ascii characters and `layerNameCString` would become `NULL`.

The C string will work as before for ASCII names, so this commit does not break compatibility. However, in the PSD spec I could not find any mention of how non-ascii layer names should be handled. It is entirely possible that this specific version of the file format did not support unicode layer names. Photoshop 2021 and its iPad counterpart seem to read layer names in a different encoding, but that could be because they are only working with what was available in the file spec PSDWriter uses. Procreate on the iPad reads unicode layer names without any issues.